### PR TITLE
Align trajectory on static reference

### DIFF
--- a/src/team/aligned_trajectories.py
+++ b/src/team/aligned_trajectories.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 
 from team.data_preprocessing import DataPreprocessing
@@ -58,14 +60,18 @@ class AlignedTrajectories:
         return trajectories
 
     @classmethod
-    def load_dataset_and_preprocess(cls, data_path: str) -> "AlignedTrajectories":
+    def load_dataset_and_preprocess(
+        cls, data_path: str, window: Optional[float] = None
+    ) -> "AlignedTrajectories":
         """
         Loads data from dataset, preprocesses it and returns the aligned trajectories
 
         :param data_path: path to the dataset
+        :param window: only allow for maximal shifts from the two diagonals smaller
+        than this number in seconds. Default to maximum.
         :return: aligned trajectories
         """
         trajectories_list = AlignedTrajectories._load_data(data_path)
         dp = DataPreprocessing(trajectories_list, sampling_rate=100)
-        dp.preprocessing()
+        dp.preprocessing(window)
         return cls.from_list_trajectories(dp.aligned_and_padded_trajectories)

--- a/src/team/gaussian_mixture_regression.py
+++ b/src/team/gaussian_mixture_regression.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from gmr import GMM
 
@@ -25,7 +27,10 @@ class GMR:
     """
 
     def __init__(
-        self, trajectories: AlignedTrajectories, prob_encoding: ProbabilisticEncoding
+        self,
+        trajectories: AlignedTrajectories,
+        prob_encoding: ProbabilisticEncoding,
+        random_state: Optional[int] = None,
     ) -> None:
         self._trajectories = trajectories
         self._gmm = GMM(
@@ -33,6 +38,7 @@ class GMR:
             priors=prob_encoding.gmm.weights_,
             means=prob_encoding.gmm.means_,
             covariances=np.array(prob_encoding.gmm.covariances_),
+            random_state=random_state,
         )
         self.prediction = self._predict_regression()
 

--- a/src/team/trajectory.py
+++ b/src/team/trajectory.py
@@ -63,8 +63,12 @@ class Trajectory(TrajectoryBase):
         return self._trajectory[:, :7]
 
     @property
-    def average_sampling(self) -> float:
-        return len(np.unique(self._trajectory, axis=0)) / self.timestamps[-1]
+    def period(self) -> float:
+        """Average time elapse between two measurements."""
+        average_time = (self.timestamps[-1] - self.timestamps[0]) / (
+            len(self.timestamps) - 1
+        )
+        return float(average_time)
 
     def upsample(self, des_freq: int) -> None:
         """

--- a/tests/tests_LfD/test_trajectory.py
+++ b/tests/tests_LfD/test_trajectory.py
@@ -155,3 +155,18 @@ class TrajectoriesTest(unittest.TestCase):
         self.assertEqual(rms_joints, np.sqrt(2))
         rms_same_traj = second_traj.rms_error(second_traj)
         self.assertEqual(rms_same_traj, 0)
+
+    def test_period(self):
+        self.trajectory.period
+        self.assertAlmostEqual(self.trajectory.period, 0.01, delta=0.002)
+
+        first_traj = Trajectory(
+            np.array(
+                [
+                    [0, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                    [2, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                ]
+            )
+        )
+        self.assertAlmostEqual(first_traj.period, 1, delta=0.002)


### PR DESCRIPTION
Previously, trajectories were aligned onto the reference trajectory and the reference was then aligned onto the last trajectory in the list. This behavior meant that the other of the trajectory had an impact on the GMM that would be extract later since the reference would be aligned differentlz depending on the order.

Since this commit, trajectories are aligned to the reference and the reference is not aligned to anything anymore. Thus, unit tests are fully reproducible regardless of the order of the trajectories.

Furthermore, the windows and psi argument are the set to 10 seconds and 2 points ot speed up computation. Test on unit tests show an improvement of around 6seconds per DTW.